### PR TITLE
update GitHub account name used in setup

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,8 +20,8 @@ EMAIL = 'contacto@nekmo.com'
 
 # Información del paquete
 PACKAGE_NAME = 'django-rest-tables'
-PACKAGE_DOWNLOAD_URL = 'https://github.com/Nekmo/django-rest-tables/archive/master.zip'  # .tar.gz
-URL = 'https://github.com/Nekmo/django-rest-tables'
+PACKAGE_DOWNLOAD_URL = 'https://github.com/alsur/django-rest-tables/archive/master.zip'  # .tar.gz
+URL = 'https://github.com/alsur/django-rest-tables'
 STATUS_LEVEL = 3  # 1:Planning 2:Pre-Alpha 3:Alpha 4:Beta 5:Production/Stable 6:Mature 7:Inactive
 KEYWORDS = ['django', 'django-rest-framework', 'tables',]  # Palabras clave
 # https://github.com/github/choosealicense.com/tree/gh-pages/_licenses


### PR DESCRIPTION
s/Nekmo\/django-rest-tables/alsur\/django-rest-tables/

Although it does break the links from PyPI, it's such a small commit that if you prefer a cleaner history, please feel free to just close this PR and roll the fix up into whatever your next edit of setup.py happens to be. 

Thanks for sharing your code!